### PR TITLE
Proposal to add nmstate-console-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nmstate-ts-proposal
+# nmstate-console-plugin-proposal
 
 Proposal to add [nmstate-console-plugin](https://github.com/upalatucci/nmstate-console-plugin) as a repo under the `nmstate` org namespace
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# nmstate-ts-proposal
+
+Proposal to add [nmstate-ts](https://github.com/upalatucci/nmstate-ts) as a repo in the `nmstate` org namespace
+
+`NMState-ts` is a typescript types library that would help developers write nmstate compatible code. 
+It generates types based on `kubenertes-nmstate` crds under `models` folder and under `custom-models` there are handcrafter non-crds types like interface 
+(Maybe later we'll find a way to generate them as well). 
+
+I'm working on another repo where these types will be used to create the [nmstate ui console plugin](https://github.com/upalatucci/nmstate-console-plugin).
+
+- [x] CI enabled and passed.
+- [x] Has integration test cases proving valid use cases. (no need for them. this library contain only types)
+- [x] Licensed under LGPL-2.0+ or Apache-2.0+(preferred).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # nmstate-ts-proposal
 
-Proposal to add [nmstate-ts](https://github.com/upalatucci/nmstate-ts) as a repo in the `nmstate` org namespace
+Proposal to add [nmstate-console-plugin](https://github.com/upalatucci/nmstate-console-plugin) as a repo under the `nmstate` org namespace
 
-`NMState-ts` is a typescript types library that would help developers write nmstate compatible code. 
-It generates types based on `kubenertes-nmstate` crds under `models` folder and under `custom-models` there are handcrafter non-crds types like interface 
-(Maybe later we'll find a way to generate them as well). 
+`nmstate-console-plugin` is an openshift web console plugin. 
+It will be used to list, create, delete and manage nmstate resources using the console UI.
 
-I'm working on another repo where these types will be used to create the [nmstate ui console plugin](https://github.com/upalatucci/nmstate-console-plugin).
+NOTE: openshift web console can be installed also in k8s clusters.
 
 - [x] CI enabled and passed.
-- [x] Has integration test cases proving valid use cases. (no need for them. this library contain only types)
+- [x] Has integration test cases proving valid use cases. (For now just one react test but we can discuss about how to create also e2e tests)
 - [x] Licensed under LGPL-2.0+ or Apache-2.0+(preferred).


### PR DESCRIPTION
# nmstate-console-plugin-proposal

Proposal to add [nmstate-console-plugin](https://github.com/upalatucci/nmstate-console-plugin) as a repo under the `nmstate` org namespace

`nmstate-console-plugin` is an openshift web console plugin. 
It will list, create, delete and manage nmstate resources using the console UI.

NOTE: 
openshift web console can also be installed in k8s clusters.
For now we have just one react test but we can discuss how to create also e2e tests.
You can find what needs to spin up a k8s cluster using `kind` in the `scripts` folder.
This setup can be used for development but also for e2e tests in ci. 
let's see what works best also for you guys :-) 

- [x] CI enabled and passed.
- [x] Has integration test cases proving valid use cases.
- [x] Licensed under LGPL-2.0+ or Apache-2.0+(preferred).